### PR TITLE
Support Guard 2

### DIFF
--- a/guard-spring.gemspec
+++ b/guard-spring.gemspec
@@ -1,6 +1,5 @@
 # -*- encoding: utf-8 -*-
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+$:.push File.expand_path("../lib", __FILE__)
 require 'guard/spring/version'
 
 Gem::Specification.new do |gem|
@@ -12,11 +11,11 @@ Gem::Specification.new do |gem|
   gem.description   = %q{Guard::Spring automatically runs tests with spring}
   gem.summary       = %q{Pushes watched files to spring}
   gem.homepage      = 'https://github.com/mknapik/guard-spring'
+  gem.license       = 'MIT'
 
-  gem.files         = `git ls-files`.split($/)
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
-  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
-  gem.require_paths = ['lib']
+  gem.files         = Dir.glob('{lib}/**/*') + %w[LICENSE.txt README.md]
+  gem.test_files    = Dir.glob('{spec}/**/*')
+  gem.require_path  = 'lib'
 
   gem.add_dependency 'guard'
   gem.add_dependency 'spring'

--- a/guard-spring.gemspec
+++ b/guard-spring.gemspec
@@ -20,4 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'guard', '>= 2.0'
   gem.add_dependency('guard-compat', '~> 0.3')
   gem.add_dependency 'spring'
+
+  gem.add_development_dependency 'rspec', '~> 3.0'
+  gem.add_development_dependency 'simplecov'
 end

--- a/guard-spring.gemspec
+++ b/guard-spring.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = Dir.glob('{spec}/**/*')
   gem.require_path  = 'lib'
 
-  gem.add_dependency 'guard'
+  gem.add_dependency 'guard', '>= 2.0'
+  gem.add_dependency('guard-compat', '~> 0.3')
   gem.add_dependency 'spring'
 end

--- a/guard-spring.gemspec
+++ b/guard-spring.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = Dir.glob('{spec}/**/*')
   gem.require_path  = 'lib'
 
-  gem.add_dependency 'guard', '>= 2.0'
-  gem.add_dependency('guard-compat', '~> 0.3')
+  gem.add_dependency 'guard', '~> 2.0'
+  gem.add_dependency 'guard-compat', '~> 1.1'
   gem.add_dependency 'spring'
 
   gem.add_development_dependency 'rspec', '~> 3.0'

--- a/lib/guard/spring.rb
+++ b/lib/guard/spring.rb
@@ -1,16 +1,15 @@
-require 'guard'
-require 'guard/guard'
+require 'guard/compat/plugin'
 require 'spring/commands'
 
 module Guard
-  class Spring < Guard
+  class Spring < Plugin
     autoload :Runner, 'guard/spring/runner'
     attr_accessor :runner
 
     # Initialize a Guard.
     # @param [Array<Guard::Watcher>] watchers the Guard file watchers
     # @param [Hash] options the custom Guard options
-    def initialize(watchers = [], options = {})
+    def initialize(options = {})
       super
       @runner = Runner.new(options)
     end

--- a/spec/guard/spring_spec.rb
+++ b/spec/guard/spring_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe Guard::Spring do
+  before do
+    # Silence UI.info output
+    allow(::Guard::UI).to receive(:info).and_return(true)
+    allow(::Guard::Notifier).to receive(:notify).and_return(true)
+  end
+
+  describe '#initialize' do
+    it "instantiates Runner with given options" do
+      expect(Guard::Spring::Runner).to receive(:new).with(foo: 'bar')
+      Guard::Spring.new(foo: 'bar')
+    end
+  end
+
+  context 'with a plugin instance' do
+    let(:options) { {} }
+    let(:plugin_instance) { described_class.new(options) }
+    before do
+      allow_any_instance_of(described_class::Runner).to receive(:get_spring_cmd).and_return('spring')
+    end
+
+    describe '#start' do
+      it "starts Runner" do
+        expect(plugin_instance.runner).to receive(:kill_spring).ordered
+        expect(plugin_instance.runner).to receive(:launch_spring).ordered
+        plugin_instance.start
+      end
+    end
+
+    describe '#run_all' do
+      it "calls Runner.run" do
+        expect(plugin_instance.runner).to receive(:run_all).with(no_args)
+        plugin_instance.run_all
+      end
+    end
+
+    describe '#run_on_changes' do
+      it "calls Runner.run with file name" do
+        expect(plugin_instance.runner).to receive(:run).with(['file_name.js'])
+        plugin_instance.run_on_changes(['file_name.js'])
+      end
+
+      it "calls Runner.run with paths" do
+        expect(plugin_instance.runner).to receive(:run).with(['spec/controllers', 'spec/requests'])
+        plugin_instance.run_on_changes(['spec/controllers', 'spec/requests'])
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,14 @@
+# -*- encoding : utf-8 -*-
+unless ENV['CI']
+  require 'simplecov'
+  SimpleCov.start do
+    add_group 'Guard::Spring', 'lib/guard'
+    add_group 'Specs', 'spec'
+  end
+end
+
+require 'rspec'
+require 'guard/compat/test/helper'
+require 'guard/spring'
+
+ENV["GUARD_ENV"] = 'test'


### PR DESCRIPTION
Use Guard's `Plugin` class. Add basic rspecs to this project. Update the gemspec to follow "modern" convention. Also, add the license (already in the project in its own file) to the gemspec.