### PR TITLE
Simplify this plugin to focus only on Spring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # Guard::Spring
 
-Guard::Spring automatically runs RSpec with [Spring](https://github.com/jonleighton/spring).
-
-Read more about [Spring](https://github.com/jonleighton/spring) - Rails application preloader.
+Guard::Spring starts, stops, and restarts [Spring](https://github.com/jonleighton/spring) - Rails application preloader. This plugin therefore most importantly ensures that Spring is not left running when Guard is stopped.
 
 Learn how to monitor file system changes with [Guard](https://github.com/guard/guard).
 
-It seems that [guard-rspec](https://github.com/guard/guard-rspec) supports *Spring* now.
+It seems that [guard-rspec](https://github.com/guard/guard-rspec) can support *Spring* now, using the `cmd` option. This plugin is used to manage Spring itself, not to inject Spring into the running of Rspec.
 
 ## Installation
 
@@ -22,15 +20,13 @@ And then execute:
 
 Add rules to Guardfile:
 
-    $ guard init spring
+    $ bundle exec guard init spring
 
 Run guard. Press Enter to run all specs.
 
-    $ guard
+    $ bundle exec guard
 
-After any modification of project file or spec should run RSpec with Spring.
-
-You can modify the Guardfile to create your own rules and dependencies to run specs.
+After any modification of monitored files Spring will be restarted.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Default values shown here.
                                        # 'bin/spring' if it exists, or 'spring'.
     bundler: false                     # If true, use 'bundle exec' to run Spring
                                        # (cmd option overrides this).
+    environments: %w(test development) # Which environments to start when Guard starts.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ Run guard. Press Enter to run all specs.
 
 After any modification of monitored files Spring will be restarted.
 
+## Options
+
+### List of available options:
+
+Default values shown here.
+
+    cmd: 'spring'                      # Specify a custom Spring command to run, default: 
+                                       # 'bundle exec spring' if bundler option is enabled,
+                                       # 'bin/spring' if it exists, or 'spring'.
+    bundler: false                     # If true, use 'bundle exec' to run Spring
+                                       # (cmd option overrides this).
+
 ## Contributing
 
 1. Fork it

--- a/lib/guard/spring.rb
+++ b/lib/guard/spring.rb
@@ -14,46 +14,43 @@ module Guard
       @runner = Runner.new(options)
     end
 
-    # Call once when Guard starts. Please override initialize method to init stuff.
+    # Called once when Guard starts. Please override initialize method to init stuff.
     # @raise [:task_has_failed] when start has failed
     def start
-      runner.kill_spring
-      runner.launch_spring('Start')
+      runner.start
     end
 
     # Called when `stop|quit|exit|s|q|e + enter` is pressed (when Guard quits).
     # @raise [:task_has_failed] when stop has failed
     def stop
-      runner.kill_spring
+      runner.stop
     end
 
     # Called when `reload|r|z + enter` is pressed.
     # This method should be mainly used for "reload" (really!) actions like reloading passenger/spork/bundler/...
     # @raise [:task_has_failed] when reload has failed
     def reload
-      runner.kill_spring
-      runner.launch_spring('Reload')
+      runner.restart
     end
 
     # Called when just `enter` is pressed
     # This method should be principally used for long action like running all specs/tests/...
     # @raise [:task_has_failed] when run_all has failed
     def run_all
-      runner.run_all
     end
 
     # Called on file(s) modifications that the Guard watches.
     # @param [Array<String>] paths the changes files or paths
     # @raise [:task_has_failed] when run_on_change has failed
     def run_on_changes(paths)
-      runner.run(paths)
+      runner.restart
     end
 
     # Called on file(s) deletions that the Guard watches.
     # @param [Array<String>] paths the deleted files or paths
     # @raise [:task_has_failed] when run_on_change has failed
     def run_on_removals(paths)
-      runner.run_all
+      runner.restart
     end
   end
 end

--- a/lib/guard/spring/runner.rb
+++ b/lib/guard/spring/runner.rb
@@ -11,6 +11,8 @@ module Guard
       end
 
       def start
+        UI.info "Guard::Spring starting Spring"
+        start_spring
       end
 
       def stop
@@ -24,6 +26,12 @@ module Guard
       end
 
       private
+
+      def start_spring
+        environments.each do |env|
+          system "#{spring_command} rake -T RAILS_ENV='#{env}' > /dev/null"
+        end
+      end
 
       def stop_spring
         system "#{spring_command} stop"
@@ -53,6 +61,10 @@ module Guard
 
       def bundler?
         options.fetch(:bundler, false)
+      end
+
+      def environments
+        options.fetch(:environments, %w(test development))
       end
     end
   end

--- a/lib/guard/spring/runner.rb
+++ b/lib/guard/spring/runner.rb
@@ -4,99 +4,53 @@ module Guard
   class Spring
     class Runner
       attr_reader :options
+      attr_writer :spring_command
 
       def initialize(options = {})
         @options = options
-        @options[:rspec_cli] = options[:rspec_cli].nil? ? '' : " #{options[:rspec_cli]} "
-        @spring_cmd = get_spring_cmd
-        UI.info 'Guard::Spring Initialized'
       end
 
-      def launch_spring(action)
-        UI.info "#{action}ing Spring", :reset => true
-        start_spring
+      def start
       end
 
-      def kill_spring
+      def stop
+        UI.info "Guard::Spring stopping Spring"
         stop_spring
       end
 
-      def run(paths)
-        existing_paths = paths.uniq.select { |path| File.exist? "#{Dir.pwd}/#{path}" }
-        rspec_paths = existing_paths.select { |path| path =~ /spec(\/\w+)*(\/\w+_spec\.rb)?/ }
-        run_command "#@spring_cmd rspec", "#{rspec_cli}#{existing_paths.join(' ')}" unless rspec_paths.empty?
-
-        # TBD: # testunit_paths = existing_paths.select { |path| path =~ /test(.*\.rb)?/ }
-        # TBD: # run_command 'spring testunit', existing_paths.join(' ') unless testunit_paths.empty?
-      end
-
-      def run_all
-        if rspec?
-          run(%w(spec))
-        elsif test_unit?
-          run(Dir['test/**/*_test.rb']+Dir['test/**/test_*.rb'])
-        end
+      def restart
+        UI.info "Guard::Spring restarting Spring"
+        stop_spring
       end
 
       private
 
-      def run_command(cmd, options = '')
-        UI.debug "Command execution: #{cmd} #{options}"
-        system "#{cmd} #{options}"
-      end
-
-      def fork_exec(cmd, options = '')
-        fork do
-          UI.debug "(Fork) Command execution: #{cmd} #{options}"
-          exec "#{cmd} #{options}"
-        end
-      end
-
-      def start_spring
-        fork_exec("#@spring_cmd start > /dev/null")
-      end
-
       def stop_spring
-        run_command("#@spring_cmd stop")
-        UI.info 'Stopping Spring ', :reset => true
+        system "#{spring_command} stop"
       end
 
-      def push_command(paths)
-        cmd_parts = []
-        cmd_parts << "#@spring_cmd rspec"
-        cmd_parts << paths.join(' ')
-        cmd_parts.join(' ')
-      end
-
-      def get_spring_cmd
-        return './bin/spring' if create_bin_stubs %w(rspec)
-
-        UI.warning('Failed to create all required binstubs')
-        'spring'
-      end
-
-      # returns false if creation of any binstub failed
-      def create_bin_stubs(stubs)
-        results = stubs.map do |stub|
-          run_command 'spring binstub', stub unless File.exist? "#{Dir.pwd}/bin/#{stub}"
+      def spring_command
+        @spring_command ||= begin
+          if bundler?
+            'bundle exec spring'
+          elsif bin_stub_exists?
+            bin_stub
+          else
+            'spring'
+          end
         end
-        !results.any? or results.all? { |result| result }
+      end
+
+      def bin_stub
+        './bin/spring'
+      end
+
+      def bin_stub_exists?
+        File.exist? bin_stub
       end
 
       def bundler?
-        @bundler ||= options[:bundler] != false && File.exist?("#{Dir.pwd}/Gemfile")
-      end
-
-      def test_unit?
-        @test_unit ||= options[:test_unit] != false && File.exist?("#{Dir.pwd}/test/test_helper.rb")
-      end
-
-      def rspec?
-        @rspec ||= options[:rspec] != false && File.exist?("#{Dir.pwd}/spec")
-      end
-
-      def rspec_cli
-        options[:rspec_cli]
+        options.fetch(:bundler, false)
       end
     end
   end

--- a/lib/guard/spring/runner.rb
+++ b/lib/guard/spring/runner.rb
@@ -31,7 +31,9 @@ module Guard
 
       def spring_command
         @spring_command ||= begin
-          if bundler?
+          if options[:cmd]
+            options[:cmd]
+          elsif bundler?
             'bundle exec spring'
           elsif bin_stub_exists?
             bin_stub

--- a/lib/guard/spring/runner.rb
+++ b/lib/guard/spring/runner.rb
@@ -23,6 +23,7 @@ module Guard
       def restart
         UI.info "Guard::Spring restarting Spring"
         stop_spring
+        start_spring
       end
 
       private

--- a/lib/guard/spring/templates/Guardfile
+++ b/lib/guard/spring/templates/Guardfile
@@ -1,9 +1,6 @@
-guard 'spring', :rspec_cli => '--color' do
-  watch(%r{^spec/.+_spec\.rb$})
-  watch(%r{^spec/spec_helper\.rb$})                   { |m| 'spec' }
-  watch(%r{^app/(.+)\.rb$})                           { |m| "spec/#{m[1]}_spec.rb" }
-  watch(%r{^lib/(.+)\.rb$})                           { |m| "spec/lib/#{m[1]}_spec.rb" }
-  watch(%r{^app/controllers/(.+)_(controller)\.rb$})  do |m|
-    %W(spec/routing/#{m[1]}_routing_spec.rb spec/#{m[2]}s/#{m[1]}_#{m[2]}_spec.rb spec/requests/#{m[1]}_spec.rb)
-  end
+guard 'spring', bundler: true do
+  watch('Gemfile.lock')
+  watch(%r{^config/})
+  watch(%r{^spec/(support|factories)/})
+  watch(%r{^spec/factory.rb})
 end

--- a/spec/guard/spring/runner_spec.rb
+++ b/spec/guard/spring/runner_spec.rb
@@ -44,11 +44,13 @@ describe Guard::Spring::Runner do
     it 'outputs a message' do
       expect(::Guard::UI).to receive(:info).with(/restarting/i)
       allow(runner).to receive(:stop_spring)
+      allow(runner).to receive(:start_spring)
       runner.restart
     end
 
-    it 'calls stop_spring' do
-      expect(runner).to receive(:stop_spring).with(no_args)
+    it 'calls stop_spring and start_spring' do
+      expect(runner).to receive(:stop_spring).with(no_args).ordered
+      expect(runner).to receive(:start_spring).with(no_args).ordered
       runner.restart
     end
   end

--- a/spec/guard/spring/runner_spec.rb
+++ b/spec/guard/spring/runner_spec.rb
@@ -15,8 +15,14 @@ describe Guard::Spring::Runner do
   end
 
   describe '#start' do
-    it 'does nothing' do
-      expect(runner).to_not receive(:stop_spring)
+    it 'outputs a message' do
+      expect(::Guard::UI).to receive(:info).with(/starting/i)
+      allow(runner).to receive(:start_spring)
+      runner.start
+    end
+
+    it 'calls start_spring' do
+      expect(runner).to receive(:start_spring).with(no_args)
       runner.start
     end
   end
@@ -103,6 +109,16 @@ describe Guard::Spring::Runner do
       allow(runner).to receive(:bin_stub).and_return(bin_stub_path)
       expect(File).to receive(:exist?).with(bin_stub_path).and_return(0xdeadbeef)
       expect(runner.send(:bin_stub_exists?)).to eq(0xdeadbeef)
+    end
+  end
+
+  describe '#start_spring' do
+    it 'makes a system call to start Spring' do
+      allow(runner).to receive(:environments).and_return(%w(env1 env2))
+      allow(runner).to receive(:spring_command).and_return('barbaz')
+      expect(runner).to receive(:system).with(/barbaz rake -T RAILS_ENV='env1'/).and_return(true)
+      expect(runner).to receive(:system).with(/barbaz rake -T RAILS_ENV='env2'/).and_return(true)
+      runner.send(:start_spring)
     end
   end
 

--- a/spec/guard/spring/runner_spec.rb
+++ b/spec/guard/spring/runner_spec.rb
@@ -1,0 +1,109 @@
+require 'spec_helper'
+
+describe Guard::Spring::Runner do
+  let(:options) { {} }
+  let(:runner) { described_class.new options }
+
+  before do
+    allow(runner).to receive(:system).and_raise(NotImplementedError)
+  end
+
+  describe '#initialize' do
+    it 'should have default options and allow overrides' do
+      expect(runner.options).to eq(options)
+    end
+  end
+
+  describe '#start' do
+    it 'does nothing' do
+      expect(runner).to_not receive(:stop_spring)
+      runner.start
+    end
+  end
+
+  describe '#stop' do
+    it 'outputs a message' do
+      expect(::Guard::UI).to receive(:info).with(/stopping/i)
+      allow(runner).to receive(:stop_spring)
+      runner.stop
+    end
+
+    it 'calls stop_spring' do
+      expect(runner).to receive(:stop_spring).with(no_args)
+      runner.stop
+    end
+  end
+
+  describe '#restart' do
+    it 'outputs a message' do
+      expect(::Guard::UI).to receive(:info).with(/restarting/i)
+      allow(runner).to receive(:stop_spring)
+      runner.restart
+    end
+
+    it 'calls stop_spring' do
+      expect(runner).to receive(:stop_spring).with(no_args)
+      runner.restart
+    end
+  end
+
+  describe '#spring_command' do
+    let(:bin_stub_exists) { false }
+    let(:bin_stub_path) { 'foo' }
+    subject { runner.send(:spring_command) }
+    before do
+      allow(runner).to receive(:bin_stub_exists?).and_return(bin_stub_exists)
+      allow(runner).to receive(:bin_stub).and_return(bin_stub_path)
+    end
+
+    context 'when bundler is enabled' do
+      let(:options) { {bundler: true} }
+
+      context 'when bin stub exists' do
+        let(:bin_stub_exists) { true }
+        it { is_expected.to eq('bundle exec spring') }
+      end
+
+      context 'when bin stub does not exist' do
+        let(:bin_stub_exists) { false }
+        it { is_expected.to eq('bundle exec spring') }
+      end
+    end
+    context 'when bundler is disabled' do
+      let(:options) { {bundler: false} }
+
+      context 'when bin stub exists' do
+        let(:bin_stub_exists) { true }
+        it { is_expected.to eq(bin_stub_path) }
+      end
+
+      context 'when bin stub does not exist' do
+        let(:bin_stub_exists) { false }
+        it { is_expected.to eq('spring') }
+      end
+    end
+  end
+
+  describe '#bin_stub' do
+    subject { runner.send(:bin_stub) }
+    it { is_expected.to eq('./bin/spring') }
+  end
+
+  describe '#bin_stub_exists?' do
+    let(:bin_stub_path) { 'foo' }
+
+    it 'checks whether the bin_stub exists' do
+      allow(runner).to receive(:bin_stub).and_return(bin_stub_path)
+      expect(File).to receive(:exist?).with(bin_stub_path).and_return(0xdeadbeef)
+      expect(runner.send(:bin_stub_exists?)).to eq(0xdeadbeef)
+    end
+  end
+
+  describe '#stop_spring' do
+    it 'makes a system call to stop Spring' do
+      allow(runner).to receive(:spring_command).and_return('spring')
+      expect(runner).to receive(:system).with(/spring stop/).and_return(true)
+      runner.send(:stop_spring)
+    end
+  end
+end

--- a/spec/guard/spring/runner_spec.rb
+++ b/spec/guard/spring/runner_spec.rb
@@ -56,30 +56,37 @@ describe Guard::Spring::Runner do
       allow(runner).to receive(:bin_stub).and_return(bin_stub_path)
     end
 
-    context 'when bundler is enabled' do
-      let(:options) { {bundler: true} }
-
-      context 'when bin stub exists' do
-        let(:bin_stub_exists) { true }
-        it { is_expected.to eq('bundle exec spring') }
-      end
-
-      context 'when bin stub does not exist' do
-        let(:bin_stub_exists) { false }
-        it { is_expected.to eq('bundle exec spring') }
-      end
+    context 'when cmd option is present' do
+      let(:options) { {cmd: 'foobar'} }
+      it { is_expected.to eq('foobar') }
     end
-    context 'when bundler is disabled' do
-      let(:options) { {bundler: false} }
 
-      context 'when bin stub exists' do
-        let(:bin_stub_exists) { true }
-        it { is_expected.to eq(bin_stub_path) }
+    context 'when cmd option is unused' do
+      context 'with bundler: true' do
+        let(:options) { {bundler: true} }
+
+        context 'when bin stub exists' do
+          let(:bin_stub_exists) { true }
+          it { is_expected.to eq('bundle exec spring') }
+        end
+
+        context 'when bin stub does not exist' do
+          let(:bin_stub_exists) { false }
+          it { is_expected.to eq('bundle exec spring') }
+        end
       end
+      context 'with bundler: false' do
+        let(:options) { {bundler: false} }
 
-      context 'when bin stub does not exist' do
-        let(:bin_stub_exists) { false }
-        it { is_expected.to eq('spring') }
+        context 'when bin stub exists' do
+          let(:bin_stub_exists) { true }
+          it { is_expected.to eq(bin_stub_path) }
+        end
+
+        context 'when bin stub does not exist' do
+          let(:bin_stub_exists) { false }
+          it { is_expected.to eq('spring') }
+        end
       end
     end
   end

--- a/spec/guard/spring_spec.rb
+++ b/spec/guard/spring_spec.rb
@@ -1,50 +1,59 @@
 require 'spec_helper'
 
 describe Guard::Spring do
-  before do
-    # Silence UI.info output
-    allow(::Guard::UI).to receive(:info).and_return(true)
-    allow(::Guard::Notifier).to receive(:notify).and_return(true)
-  end
-
   describe '#initialize' do
     it "instantiates Runner with given options" do
-      expect(Guard::Spring::Runner).to receive(:new).with(foo: 'bar')
-      Guard::Spring.new(foo: 'bar')
+      expect(described_class::Runner).to receive(:new).with(foo: 'bar')
+      described_class.new(foo: 'bar')
     end
   end
 
   context 'with a plugin instance' do
     let(:options) { {} }
     let(:plugin_instance) { described_class.new(options) }
+    let(:runner) { double(described_class::Runner) }
     before do
-      allow_any_instance_of(described_class::Runner).to receive(:get_spring_cmd).and_return('spring')
+      allow(plugin_instance).to receive(:runner).and_return(runner)
     end
 
     describe '#start' do
-      it "starts Runner" do
-        expect(plugin_instance.runner).to receive(:kill_spring).ordered
-        expect(plugin_instance.runner).to receive(:launch_spring).ordered
+      it "call runner.start" do
+        expect(runner).to receive(:start).with(no_args)
         plugin_instance.start
       end
     end
 
+    describe '#stop' do
+      it "call runner.stop" do
+        expect(runner).to receive(:stop).with(no_args)
+        plugin_instance.stop
+      end
+    end
+
+    describe '#reload' do
+      it "calls runner.restart" do
+        expect(runner).to receive(:restart).with(no_args)
+        plugin_instance.reload
+      end
+    end
+
     describe '#run_all' do
-      it "calls Runner.run" do
-        expect(plugin_instance.runner).to receive(:run_all).with(no_args)
+      it "does nothing" do
         plugin_instance.run_all
       end
     end
 
     describe '#run_on_changes' do
-      it "calls Runner.run with file name" do
-        expect(plugin_instance.runner).to receive(:run).with(['file_name.js'])
-        plugin_instance.run_on_changes(['file_name.js'])
+      it "calls runner.restart" do
+        expect(runner).to receive(:restart).with(no_args)
+        plugin_instance.run_on_changes('foo')
       end
+    end
 
-      it "calls Runner.run with paths" do
-        expect(plugin_instance.runner).to receive(:run).with(['spec/controllers', 'spec/requests'])
-        plugin_instance.run_on_changes(['spec/controllers', 'spec/requests'])
+    describe '#run_on_removals' do
+      it "calls runner.restart" do
+        expect(runner).to receive(:restart).with(no_args)
+        plugin_instance.run_on_removals('foo')
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,3 +12,11 @@ require 'guard/compat/test/helper'
 require 'guard/spring'
 
 ENV["GUARD_ENV"] = 'test'
+
+RSpec.configure do |config|
+  config.before(:each) do
+    # Silence UI.info output
+    allow(::Guard::UI).to receive(:info).and_return(true)
+    allow(::Guard::Notifier).to receive(:notify).and_return(true)
+  end
+end


### PR DESCRIPTION
_This branch is built on top of #2, which updates the plugin to support Guard 2. So #2 should be merged before this PR._

Since Spring itself can now be supported by the Rspec Guard plugin very easily, it's not worth this plugin existing for the running of Rspec.

So this turns the Spring plugin into a simple controller of Spring. It starts Spring on startup, and stops it on shutdown. It allows it to be restarted along with the other items that Guard is controlling. Spring itself also knows when it's time to restart, but it doesn't always, so this allows a project that uses Guard extensively to control Spring in the same way it might be controlling, for example, Pow.

Finally, add specs for everything.
